### PR TITLE
Use dev_dependencies for `test` package

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,5 +5,5 @@ author: Yuki Awano <y.a.unix@gmail.com>
 homepage: http://www.yaunix.com/
 environment:
   sdk: ">=2.1.0 <3.0.0"
-dependencies:
+dev_dependencies:
   test: 1.6.3


### PR DESCRIPTION
Thanks for making fork for Dart 2. This package helped me quite a lot.

However, there's one minor problem with this package: this package list `test` package in `dependencies` instead of `dev_depencenies`.

As a result, if a package use this package as dependency, it also unintentionally 
 installs [these 24 packages](https://github.com/dart-lang/test/blob/master/pkgs/test/pubspec.yaml#L10-L35) as dependencies too.

**Reference:**
https://dart.dev/tools/pub/dependencies#dev-dependencies
> ... If it’s only imported from test, example, etc. it can and should be a dev dependency.